### PR TITLE
feat: add textbooks, work requirements, and exams to knowledge graph

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -25,6 +25,9 @@ _cache = {
     "subjects": {},  # inst -> {subject -> count}
     "prerequisites": [],  # list of {from, to}
     "transfers": [],  # list of transfer pathways
+    "textbooks": {},  # isbn -> textbook dict
+    "work_requirements": {},  # ref_id -> work requirement dict
+    "exams": {},  # ref_id -> exam dict
     "loaded": False,
 }
 
@@ -50,7 +53,9 @@ def ensure_cache():
     # Process nodes
     subjects_by_inst = {}
     for node in data.get("nodes", []):
-        if node.get("type") == "course":
+        node_type = node.get("type", "course")
+
+        if node_type == "course":
             inst = node.get("institution", "unknown")
             code = node.get("label", "")
             subject = node.get("subject", code.split()[0] if code else "")
@@ -70,11 +75,42 @@ def ensure_cache():
                 subjects_by_inst[inst][subject] = 0
             subjects_by_inst[inst][subject] += 1
 
+        elif node_type == "textbook":
+            _cache["textbooks"][node["id"]] = {
+                "id": node["id"],
+                "isbn": node.get("isbn", ""),
+                "title": node.get("title", node.get("label", "")),
+                "authors": node.get("authors", []),
+            }
+
+        elif node_type == "work_requirement":
+            _cache["work_requirements"][node["id"]] = {
+                "id": node["id"],
+                "title": node.get("label", ""),
+                "description": node.get("title", ""),
+                "work_type": node.get("work_type", "assignment"),
+                "weight": node.get("weight", 0),
+                "course": node.get("course", ""),
+                "institution": node.get("institution", ""),
+            }
+
+        elif node_type == "exam":
+            _cache["exams"][node["id"]] = {
+                "id": node["id"],
+                "title": node.get("label", "Final Examination"),
+                "description": node.get("title", ""),
+                "weight": node.get("weight", 0),
+                "duration_minutes": node.get("duration_minutes", 180),
+                "course": node.get("course", ""),
+                "institution": node.get("institution", ""),
+            }
+
     _cache["subjects"] = subjects_by_inst
 
-    # Process prerequisite links
+    # Process links (all edge types)
     for link in data.get("links", []):
-        if link.get("type") == "prerequisite":
+        link_type = link.get("type", "prerequisite")
+        if link_type == "prerequisite":
             _cache["prerequisites"].append({
                 "from": link["source"],
                 "to": link["target"],
@@ -215,6 +251,163 @@ def get_stats():
         "subjects": len(subjects),
         "prerequisites": len(_cache["prerequisites"]),
         "transfers": len(_cache["transfers"]),
+        "textbooks": len(_cache["textbooks"]),
+        "work_requirements": len(_cache["work_requirements"]),
+        "exams": len(_cache["exams"]),
+    })
+
+
+# --- Textbook Endpoints ---
+
+@app.route("/api/textbooks")
+def list_textbooks():
+    """List all textbooks."""
+    ensure_cache()
+    course_id = request.args.get("course")
+
+    textbooks = list(_cache["textbooks"].values())
+
+    # If filtering by course, find textbooks linked to that course
+    if course_id:
+        # Would require edge data - for now return all
+        pass
+
+    return jsonify(sorted(textbooks, key=lambda x: x.get("title", "")))
+
+
+@app.route("/api/textbook/<path:textbook_id>")
+def get_textbook(textbook_id: str):
+    """Get details for a specific textbook."""
+    ensure_cache()
+
+    textbook = _cache["textbooks"].get(textbook_id)
+    if not textbook:
+        return jsonify({"error": f"Textbook not found: {textbook_id}"}), 404
+
+    return jsonify(textbook)
+
+
+# --- Work Requirement Endpoints ---
+
+@app.route("/api/work-requirements")
+def list_work_requirements():
+    """List work requirements, optionally filtered by course."""
+    ensure_cache()
+    course_id = request.args.get("course")
+    work_type = request.args.get("type")
+
+    requirements = []
+    for req in _cache["work_requirements"].values():
+        if course_id and req.get("course") != course_id:
+            continue
+        if work_type and req.get("work_type") != work_type:
+            continue
+        requirements.append(req)
+
+    return jsonify(sorted(requirements, key=lambda x: x.get("title", "")))
+
+
+@app.route("/api/work-requirement/<path:req_id>")
+def get_work_requirement(req_id: str):
+    """Get details for a specific work requirement."""
+    ensure_cache()
+
+    req = _cache["work_requirements"].get(req_id)
+    if not req:
+        return jsonify({"error": f"Work requirement not found: {req_id}"}), 404
+
+    return jsonify(req)
+
+
+# --- Exam Endpoints ---
+
+@app.route("/api/exams")
+def list_exams():
+    """List all exams, optionally filtered."""
+    ensure_cache()
+    course_id = request.args.get("course")
+    institution = request.args.get("institution")
+
+    exams = []
+    for exam in _cache["exams"].values():
+        if course_id and exam.get("course") != course_id:
+            continue
+        if institution and exam.get("institution") != institution:
+            continue
+        exams.append(exam)
+
+    return jsonify(sorted(exams, key=lambda x: x.get("title", "")))
+
+
+@app.route("/api/exam/<path:exam_id>")
+def get_exam(exam_id: str):
+    """Get details for a specific exam."""
+    ensure_cache()
+
+    exam = _cache["exams"].get(exam_id)
+    if not exam:
+        return jsonify({"error": f"Exam not found: {exam_id}"}), 404
+
+    # Find dependencies (work requirements that lead to this exam)
+    dependencies = []
+    # This would require edge data - placeholder for now
+
+    return jsonify({
+        **exam,
+        "dependencies": dependencies,
+    })
+
+
+# --- Course Completion Endpoint ---
+
+@app.route("/api/course/<path:course_id>/completion")
+def get_course_completion(course_id: str):
+    """
+    Get complete course requirements including textbooks, work, and exams.
+
+    This endpoint returns the full directed graph of what's needed to
+    complete a course, with the final exam as the terminal node.
+    """
+    ensure_cache()
+
+    # Normalize course ID
+    if ":" not in course_id:
+        course_id = f"usask:{course_id}"
+
+    course = _cache["courses"].get(course_id)
+    if not course:
+        return jsonify({"error": f"Course not found: {course_id}"}), 404
+
+    # Find associated data
+    work_reqs = [
+        req for req in _cache["work_requirements"].values()
+        if req.get("course") == course_id
+    ]
+
+    exams = [
+        exam for exam in _cache["exams"].values()
+        if exam.get("course") == course_id
+    ]
+
+    # Find final exam (terminal node)
+    final_exam = None
+    midterms = []
+    for exam in exams:
+        if "final" in exam.get("title", "").lower():
+            final_exam = exam
+        else:
+            midterms.append(exam)
+
+    return jsonify({
+        "course": course,
+        "work_requirements": work_reqs,
+        "midterms": midterms,
+        "final_exam": final_exam,
+        "graph": {
+            "description": "Final exam depends on completing all work requirements",
+            "terminal_node": final_exam["id"] if final_exam else None,
+            "work_nodes": [w["id"] for w in work_reqs],
+        }
     })
 
 
@@ -227,6 +420,14 @@ if __name__ == "__main__":
     print("  GET /api/subjects")
     print("  GET /api/courses?subject=CMPT&institution=usask")
     print("  GET /api/course/<id>")
+    print("  GET /api/course/<id>/completion  (full course requirements graph)")
     print("  GET /api/prerequisites")
     print("  GET /api/transfers")
+    print("\nNew - Course Materials & Completion:")
+    print("  GET /api/textbooks")
+    print("  GET /api/textbook/<id>")
+    print("  GET /api/work-requirements?course=<id>&type=<type>")
+    print("  GET /api/work-requirement/<id>")
+    print("  GET /api/exams?course=<id>&institution=<inst>")
+    print("  GET /api/exam/<id>")
     app.run(debug=True, port=5050)

--- a/devvyn/data/__init__.py
+++ b/devvyn/data/__init__.py
@@ -1,0 +1,1 @@
+"""Sample data and data builders for the knowledge mapper."""

--- a/devvyn/data/sample_course_completion.py
+++ b/devvyn/data/sample_course_completion.py
@@ -1,0 +1,351 @@
+"""
+Sample course completion data demonstrating textbooks, work requirements, and exams.
+
+This file shows how to model a complete course with:
+- Required textbooks and materials
+- Assignments, labs, and projects
+- Midterm and final exams as terminal nodes in the directed graph
+
+The graph structure for a course like CMPT 141:
+
+    Textbook (Zelle) ──────────────────────────────────────┐
+         │                                                 │
+         ▼                                                 │
+    Reading Ch.1-3 ──► Assignment 1 ──┐                    │
+                                      │                    │
+    Reading Ch.4-6 ──► Assignment 2 ──┼──► Midterm ───┐    │
+                           │          │               │    │
+    Reading Ch.7-9 ──► Lab 1-4 ───────┘               │    │
+                           │                          │    │
+    Reading Ch.10-12 ──► Project ─────────────────────┼──► Final Exam
+                                                      │
+                           Midterm ───────────────────┘
+"""
+from devvyn.institutions.base import CourseReference
+from devvyn.model.course_materials import (
+    Textbook,
+    TextbookReference,
+    WorkRequirement,
+    WorkRequirementRef,
+    WorkRequirementType,
+    FinalExam,
+    ExamRef,
+    CourseCompletion,
+    MaterialType,
+)
+
+
+def create_cmpt141_completion() -> CourseCompletion:
+    """
+    Create a complete course model for CMPT 141 - Introduction to Computer Science.
+
+    This demonstrates all the new model types working together.
+    """
+    course_ref = CourseReference(institution="usask", code="CMPT 141")
+
+    # --- Textbooks ---
+    zelle_textbook = Textbook(
+        ref=TextbookReference(isbn="9781590282755"),
+        title="Python Programming: An Introduction to Computer Science",
+        authors=["John Zelle"],
+        edition="3rd",
+        publisher="Franklin, Beedle & Associates",
+        year=2016,
+        material_type=MaterialType.TEXTBOOK,
+        chapters=[
+            "Chapter 1: Computers and Programs",
+            "Chapter 2: Writing Simple Programs",
+            "Chapter 3: Computing with Numbers",
+            "Chapter 4: Objects and Graphics",
+            "Chapter 5: Sequences: Strings, Lists, and Files",
+            "Chapter 6: Defining Functions",
+            "Chapter 7: Decision Structures",
+            "Chapter 8: Loop Structures and Booleans",
+            "Chapter 9: Simulation and Design",
+            "Chapter 10: Defining Classes",
+            "Chapter 11: Data Collections",
+            "Chapter 12: Object-Oriented Design",
+        ],
+        total_pages=552,
+        url="https://fbeedle.com/our-books/13-python-programming-702.html",
+    )
+
+    # --- Readings (from textbook) ---
+    def make_reading(chapters: str, week: int) -> WorkRequirement:
+        """Helper to create reading requirements."""
+        return WorkRequirement(
+            ref=WorkRequirementRef(
+                course_ref=course_ref,
+                req_type=WorkRequirementType.READING,
+                identifier=f"reading-week{week}",
+            ),
+            title=f"Reading: {chapters}",
+            description=f"Complete readings from textbook: {chapters}",
+            weight_percent=0,  # Readings not graded directly
+            estimated_hours=3.0,
+            textbook_readings=[(zelle_textbook.ref, chapters)],
+            due_week=week,
+        )
+
+    readings = [
+        make_reading("Chapters 1-3", week=2),
+        make_reading("Chapters 4-5", week=4),
+        make_reading("Chapters 6-7", week=6),
+        make_reading("Chapters 8-9", week=8),
+        make_reading("Chapters 10-11", week=10),
+        make_reading("Chapter 12", week=12),
+    ]
+
+    # --- Assignments ---
+    def make_assignment(num: int, title: str, week: int, prereq_reading_idx: int) -> WorkRequirement:
+        """Helper to create assignments."""
+        deps = [readings[prereq_reading_idx].ref] if prereq_reading_idx >= 0 else []
+        return WorkRequirement(
+            ref=WorkRequirementRef(
+                course_ref=course_ref,
+                req_type=WorkRequirementType.ASSIGNMENT,
+                identifier=f"a{num}",
+            ),
+            title=f"Assignment {num}: {title}",
+            description=f"Programming assignment covering {title.lower()}",
+            weight_percent=5.0,  # Each assignment worth 5%
+            estimated_hours=8.0,
+            depends_on=deps,
+            due_week=week,
+        )
+
+    assignments = [
+        make_assignment(1, "Variables and Expressions", week=3, prereq_reading_idx=0),
+        make_assignment(2, "Graphics and Objects", week=5, prereq_reading_idx=1),
+        make_assignment(3, "Functions", week=7, prereq_reading_idx=2),
+        make_assignment(4, "Loops and Conditionals", week=9, prereq_reading_idx=3),
+        make_assignment(5, "Classes and Objects", week=11, prereq_reading_idx=4),
+    ]
+
+    # --- Labs ---
+    def make_lab(num: int, topic: str, week: int) -> WorkRequirement:
+        """Helper to create labs."""
+        return WorkRequirement(
+            ref=WorkRequirementRef(
+                course_ref=course_ref,
+                req_type=WorkRequirementType.LAB,
+                identifier=f"lab{num}",
+            ),
+            title=f"Lab {num}: {topic}",
+            description=f"Hands-on lab exercise: {topic}",
+            weight_percent=2.0,  # Each lab worth 2%
+            estimated_hours=2.0,
+            due_week=week,
+        )
+
+    labs = [
+        make_lab(1, "Python Setup and Basics", week=1),
+        make_lab(2, "Variables and Input/Output", week=2),
+        make_lab(3, "Graphics Programming", week=4),
+        make_lab(4, "Functions and Decomposition", week=6),
+        make_lab(5, "Conditionals", week=7),
+        make_lab(6, "Loops", week=8),
+        make_lab(7, "Lists and Strings", week=9),
+        make_lab(8, "File I/O", week=10),
+        make_lab(9, "Classes", week=11),
+        make_lab(10, "Review and Practice", week=12),
+    ]
+
+    # --- Midterm ---
+    midterm = FinalExam(
+        ref=ExamRef(course_ref=course_ref, exam_type="midterm"),
+        title="Midterm Examination",
+        description="Covers Chapters 1-7: basics, graphics, functions, conditionals",
+        weight_percent=20.0,
+        duration_minutes=90,
+        is_cumulative=False,
+        has_multiple_choice=True,
+        has_short_answer=True,
+        has_coding_problems=True,
+        required_work=[
+            assignments[0].ref,
+            assignments[1].ref,
+            assignments[2].ref,
+            labs[0].ref,
+            labs[1].ref,
+            labs[2].ref,
+            labs[3].ref,
+            labs[4].ref,
+        ],
+        topics=["Variables", "Expressions", "Graphics", "Functions", "Conditionals"],
+        textbook_coverage=[(zelle_textbook.ref, "Chapters 1-7")],
+        exam_period="October 2025",
+    )
+
+    # --- Final Exam ---
+    final_exam = FinalExam(
+        ref=ExamRef(course_ref=course_ref, exam_type="final"),
+        title="Final Examination",
+        description="Cumulative exam covering all course material",
+        weight_percent=35.0,
+        duration_minutes=180,
+        is_cumulative=True,
+        has_multiple_choice=True,
+        has_short_answer=True,
+        has_coding_problems=True,
+        required_work=[
+            a.ref for a in assignments
+        ] + [
+            l.ref for l in labs
+        ] + [
+            midterm.ref,
+        ],
+        topics=[
+            "Variables and Expressions",
+            "Graphics and Objects",
+            "Functions",
+            "Decision Structures",
+            "Loop Structures",
+            "Strings and Lists",
+            "File I/O",
+            "Classes and OOP",
+            "Design and Testing",
+        ],
+        textbook_coverage=[(zelle_textbook.ref, "All Chapters (1-12)")],
+        exam_period="December 2025",
+        min_grade_percent=40.0,  # Must pass exam to pass course
+    )
+
+    # --- Assemble Course Completion ---
+    return CourseCompletion(
+        course_ref=course_ref,
+        course_title="Introduction to Computer Science",
+        required_textbooks=[zelle_textbook],
+        assignments=assignments,
+        labs=labs,
+        readings=readings,
+        midterms=[midterm],
+        final_exam=final_exam,
+    )
+
+
+def create_cmpt145_completion() -> CourseCompletion:
+    """
+    Create a complete course model for CMPT 145 - Principles of Computer Science.
+
+    Builds on CMPT 141, demonstrating prerequisite relationships.
+    """
+    course_ref = CourseReference(institution="usask", code="CMPT 145")
+
+    # Different textbook for data structures
+    textbook = Textbook(
+        ref=TextbookReference(isbn="9780134855684"),
+        title="Data Structures and Algorithms in Python",
+        authors=["Michael T. Goodrich", "Roberto Tamassia", "Michael H. Goldwasser"],
+        edition="1st",
+        publisher="Wiley",
+        year=2013,
+        material_type=MaterialType.TEXTBOOK,
+        chapters=[
+            "Chapter 1: Python Primer",
+            "Chapter 2: Object-Oriented Programming",
+            "Chapter 3: Algorithm Analysis",
+            "Chapter 4: Recursion",
+            "Chapter 5: Array-Based Sequences",
+            "Chapter 6: Stacks, Queues, and Deques",
+            "Chapter 7: Linked Lists",
+            "Chapter 8: Trees",
+        ],
+        total_pages=748,
+    )
+
+    # Simplified - just show the final exam as terminal node
+    assignments = [
+        WorkRequirement(
+            ref=WorkRequirementRef(course_ref, WorkRequirementType.ASSIGNMENT, f"a{i}"),
+            title=f"Assignment {i}",
+            weight_percent=6.0,
+            estimated_hours=10.0,
+            due_week=i * 2 + 1,
+        )
+        for i in range(1, 6)
+    ]
+
+    final_exam = FinalExam(
+        ref=ExamRef(course_ref=course_ref, exam_type="final"),
+        title="Final Examination",
+        description="Comprehensive exam on data structures and algorithms",
+        weight_percent=40.0,
+        duration_minutes=180,
+        is_cumulative=True,
+        has_coding_problems=True,
+        has_proofs=True,
+        required_work=[a.ref for a in assignments],
+        topics=["Recursion", "Algorithm Analysis", "Stacks", "Queues", "Linked Lists", "Trees"],
+        textbook_coverage=[(textbook.ref, "All Chapters")],
+        exam_period="December 2025",
+    )
+
+    return CourseCompletion(
+        course_ref=course_ref,
+        course_title="Principles of Computer Science",
+        required_textbooks=[textbook],
+        assignments=assignments,
+        final_exam=final_exam,
+    )
+
+
+def get_sample_completions() -> list[CourseCompletion]:
+    """Get all sample course completions."""
+    return [
+        create_cmpt141_completion(),
+        create_cmpt145_completion(),
+    ]
+
+
+if __name__ == "__main__":
+    # Demo: Print the dependency graph for CMPT 141
+    completion = create_cmpt141_completion()
+
+    print(f"Course: {completion.course_title}")
+    print(f"Course ID: {completion.course_ref}")
+    print()
+
+    print("Required Textbooks:")
+    for tb in completion.required_textbooks:
+        print(f"  - {tb}")
+    print()
+
+    print(f"Work Requirements ({len(completion.all_work_requirements)} total):")
+    print(f"  - {len(completion.assignments)} assignments ({sum(a.weight_percent for a in completion.assignments)}%)")
+    print(f"  - {len(completion.labs)} labs ({sum(l.weight_percent for l in completion.labs)}%)")
+    print(f"  - {len(completion.readings)} readings")
+    print()
+
+    print("Exams:")
+    for exam in completion.all_exams:
+        print(f"  - {exam.title}: {exam.weight_percent}% (depends on {len(exam.required_work)} work items)")
+    print()
+
+    print("Final Exam (Terminal Node):")
+    if completion.final_exam:
+        print(f"  Title: {completion.final_exam.title}")
+        print(f"  Weight: {completion.final_exam.weight_percent}%")
+        print(f"  Duration: {completion.final_exam.duration_minutes} minutes")
+        print(f"  Prerequisites: {len(completion.final_exam.required_work)} work requirements")
+        print(f"  Topics: {', '.join(completion.final_exam.topics[:5])}...")
+    print()
+
+    print("Dependency Graph (work → exam):")
+    graph = completion.build_dependency_graph()
+    for node, deps in sorted(graph.items()):
+        if deps:
+            print(f"  {node}")
+            for d in deps[:3]:
+                print(f"    ← {d}")
+            if len(deps) > 3:
+                print(f"    ... and {len(deps) - 3} more")
+
+    # Validate weights
+    issues = completion.validate_weights()
+    if issues:
+        print("\nWeight validation issues:")
+        for issue in issues:
+            print(f"  ⚠ {issue}")
+    else:
+        print("\n✓ Weights sum to 100%")

--- a/devvyn/graph/curriculum.py
+++ b/devvyn/graph/curriculum.py
@@ -1,0 +1,427 @@
+"""
+Extended curriculum graph supporting courses, materials, work requirements, and exams.
+
+This graph extends the prerequisite graph to model complete course structures:
+- Courses with their prerequisites (existing functionality)
+- Textbooks associated with courses
+- Work requirements (assignments, labs, projects) within courses
+- Final exams as terminal nodes that depend on completing work
+
+Graph Structure:
+    ┌─────────────────────────────────────────────────────────────┐
+    │                     COURSE LEVEL                            │
+    │  Course_A ─────prerequisite────► Course_B                   │
+    └─────────────────────────────────────────────────────────────┘
+                           │
+                           │ (course contains)
+                           ▼
+    ┌─────────────────────────────────────────────────────────────┐
+    │                   MATERIALS LEVEL                           │
+    │                                                             │
+    │  Textbook_1 ◄───uses──── Course_B ────uses───► Textbook_2   │
+    │      │                       │                    │         │
+    │      ▼                       ▼                    ▼         │
+    │  [Chapters]            [Work Reqs]           [Chapters]     │
+    └─────────────────────────────────────────────────────────────┘
+                           │
+                           │ (work dependencies)
+                           ▼
+    ┌─────────────────────────────────────────────────────────────┐
+    │                WORK REQUIREMENT LEVEL                       │
+    │                                                             │
+    │  Reading_Ch1 ──► Assignment_1 ──┐                           │
+    │                                 │                           │
+    │  Reading_Ch2 ──► Lab_1 ─────────┼──► Midterm_1              │
+    │                                 │         │                 │
+    │  Reading_Ch3 ──► Lab_2 ─────────┘         │                 │
+    │       │                                   │                 │
+    │       └───────► Project ──────────────────┼──► Final_Exam   │
+    │                                           │                 │
+    │                  Midterm_1 ───────────────┘                 │
+    └─────────────────────────────────────────────────────────────┘
+"""
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Optional, Union
+
+from devvyn.institutions.base import CourseReference, UnifiedCourse
+from devvyn.model.course_materials import (
+    Textbook,
+    TextbookReference,
+    WorkRequirement,
+    WorkRequirementRef,
+    FinalExam,
+    ExamRef,
+    CourseCompletion,
+    GraphNode,
+    GraphEdge,
+    NodeType,
+    EdgeType,
+)
+
+
+# Type alias for any graph node reference
+NodeRef = Union[CourseReference, TextbookReference, WorkRequirementRef, ExamRef, str]
+
+
+@dataclass
+class CurriculumGraph:
+    """
+    A comprehensive curriculum graph that models courses, materials, work, and exams.
+
+    This extends the prerequisite graph to support fine-grained modeling of
+    what's required to complete a course or program.
+    """
+
+    # All nodes by type
+    _courses: dict[CourseReference, UnifiedCourse] = field(default_factory=dict)
+    _textbooks: dict[TextbookReference, Textbook] = field(default_factory=dict)
+    _work_requirements: dict[WorkRequirementRef, WorkRequirement] = field(default_factory=dict)
+    _exams: dict[ExamRef, FinalExam] = field(default_factory=dict)
+    _course_completions: dict[CourseReference, CourseCompletion] = field(default_factory=dict)
+
+    # Forward edges: node → set of nodes that depend on it
+    _forward: dict[str, set[str]] = field(default_factory=lambda: defaultdict(set))
+
+    # Backward edges: node → set of nodes it depends on
+    _backward: dict[str, set[str]] = field(default_factory=lambda: defaultdict(set))
+
+    # Edge metadata
+    _edge_types: dict[tuple[str, str], EdgeType] = field(default_factory=dict)
+
+    # --- Node Operations ---
+
+    def add_course(self, course: UnifiedCourse) -> None:
+        """Add a course to the graph."""
+        self._courses[course.ref] = course
+
+        # Add prerequisite edges
+        for prereq_ref in course.prerequisites:
+            self._add_edge(str(prereq_ref), str(course.ref), EdgeType.PREREQUISITE)
+
+        # Add corequisite edges (bidirectional)
+        for coreq_ref in course.corequisites:
+            self._add_edge(str(coreq_ref), str(course.ref), EdgeType.COREQUISITE)
+            self._add_edge(str(course.ref), str(coreq_ref), EdgeType.COREQUISITE)
+
+    def add_textbook(self, textbook: Textbook) -> None:
+        """Add a textbook to the graph."""
+        self._textbooks[textbook.ref] = textbook
+
+    def add_work_requirement(self, work: WorkRequirement) -> None:
+        """Add a work requirement to the graph."""
+        self._work_requirements[work.ref] = work
+
+        # Add edges for dependencies
+        for dep_ref in work.depends_on:
+            self._add_edge(str(dep_ref), str(work.ref), EdgeType.DEPENDS_ON)
+
+        # Add edges for textbook readings
+        for textbook_ref, section in work.textbook_readings:
+            reading_node = f"{textbook_ref}:{section}"
+            self._add_edge(reading_node, str(work.ref), EdgeType.REQUIRES_READING)
+
+    def add_exam(self, exam: FinalExam) -> None:
+        """Add an exam to the graph."""
+        self._exams[exam.ref] = exam
+
+        # Add edges from work requirements to exam
+        for work_ref in exam.required_work:
+            self._add_edge(str(work_ref), str(exam.ref), EdgeType.LEADS_TO_EXAM)
+
+    def add_course_completion(self, completion: CourseCompletion) -> None:
+        """
+        Add complete course requirements including materials and exams.
+
+        This is the main entry point for adding rich course data.
+        """
+        self._course_completions[completion.course_ref] = completion
+
+        # Add textbooks
+        for textbook in completion.required_textbooks + completion.recommended_textbooks:
+            self.add_textbook(textbook)
+            # Link course to textbook
+            self._add_edge(
+                str(completion.course_ref),
+                str(textbook.ref),
+                EdgeType.USES_TEXTBOOK
+            )
+
+        # Add work requirements
+        for work in completion.all_work_requirements:
+            self.add_work_requirement(work)
+
+        # Add exams
+        for exam in completion.all_exams:
+            self.add_exam(exam)
+
+    def _add_edge(self, source: str, target: str, edge_type: EdgeType) -> None:
+        """Add a directed edge to the graph."""
+        self._forward[source].add(target)
+        self._backward[target].add(source)
+        self._edge_types[(source, target)] = edge_type
+
+    # --- Query Operations ---
+
+    def get_course(self, ref: CourseReference) -> Optional[UnifiedCourse]:
+        """Get a course by reference."""
+        return self._courses.get(ref)
+
+    def get_textbook(self, ref: TextbookReference) -> Optional[Textbook]:
+        """Get a textbook by reference."""
+        return self._textbooks.get(ref)
+
+    def get_work_requirement(self, ref: WorkRequirementRef) -> Optional[WorkRequirement]:
+        """Get a work requirement by reference."""
+        return self._work_requirements.get(ref)
+
+    def get_exam(self, ref: ExamRef) -> Optional[FinalExam]:
+        """Get an exam by reference."""
+        return self._exams.get(ref)
+
+    def get_course_completion(self, ref: CourseReference) -> Optional[CourseCompletion]:
+        """Get full course completion requirements."""
+        return self._course_completions.get(ref)
+
+    def dependencies_for(self, node_id: str, transitive: bool = True) -> set[str]:
+        """
+        Get all nodes that this node depends on.
+
+        Args:
+            node_id: Node identifier
+            transitive: If True, include transitive dependencies
+
+        Returns:
+            Set of node IDs this node depends on
+        """
+        if not transitive:
+            return self._backward.get(node_id, set()).copy()
+
+        # BFS for transitive dependencies
+        visited = set()
+        queue = list(self._backward.get(node_id, []))
+
+        while queue:
+            dep = queue.pop(0)
+            if dep in visited:
+                continue
+            visited.add(dep)
+            queue.extend(self._backward.get(dep, []))
+
+        return visited
+
+    def dependents_of(self, node_id: str, transitive: bool = True) -> set[str]:
+        """
+        Get all nodes that depend on this node.
+
+        Args:
+            node_id: Node identifier
+            transitive: If True, include transitive dependents
+
+        Returns:
+            Set of node IDs that depend on this node
+        """
+        if not transitive:
+            return self._forward.get(node_id, set()).copy()
+
+        # BFS for transitive dependents
+        visited = set()
+        queue = list(self._forward.get(node_id, []))
+
+        while queue:
+            dep = queue.pop(0)
+            if dep in visited:
+                continue
+            visited.add(dep)
+            queue.extend(self._forward.get(dep, []))
+
+        return visited
+
+    def path_to_exam(self, exam_ref: ExamRef) -> list[list[str]]:
+        """
+        Find all paths from entry-level work to a final exam.
+
+        Useful for visualizing what needs to be done to prepare for an exam.
+        """
+        exam_id = str(exam_ref)
+        paths = []
+
+        # Find entry points (nodes with no dependencies in this course)
+        course_ref = exam_ref.course_ref
+        entry_points = []
+
+        for work_ref in self._work_requirements:
+            if work_ref.course_ref == course_ref:
+                work_id = str(work_ref)
+                # Entry point if no dependencies or only textbook dependencies
+                deps = self._backward.get(work_id, set())
+                if not deps or all("isbn:" in d for d in deps):
+                    entry_points.append(work_id)
+
+        # DFS from each entry point to exam
+        for entry in entry_points:
+            self._find_paths_dfs(entry, exam_id, [entry], paths, max_depth=20)
+
+        return paths
+
+    def _find_paths_dfs(
+        self,
+        current: str,
+        target: str,
+        path: list[str],
+        all_paths: list[list[str]],
+        max_depth: int
+    ) -> None:
+        """DFS helper for finding paths."""
+        if len(path) > max_depth:
+            return
+
+        if current == target:
+            all_paths.append(path.copy())
+            return
+
+        for next_node in self._forward.get(current, []):
+            if next_node not in path:
+                path.append(next_node)
+                self._find_paths_dfs(next_node, target, path, all_paths, max_depth)
+                path.pop()
+
+    def get_final_exams(self, institution: Optional[str] = None) -> list[FinalExam]:
+        """Get all final exams, optionally filtered by institution."""
+        exams = list(self._exams.values())
+        if institution:
+            exams = [e for e in exams if e.course_ref.institution == institution]
+        return exams
+
+    def get_work_for_course(self, course_ref: CourseReference) -> list[WorkRequirement]:
+        """Get all work requirements for a course."""
+        return [
+            w for w in self._work_requirements.values()
+            if w.course_ref == course_ref
+        ]
+
+    def get_textbooks_for_course(self, course_ref: CourseReference) -> list[Textbook]:
+        """Get all textbooks used by a course."""
+        course_id = str(course_ref)
+        textbooks = []
+        for target in self._forward.get(course_id, []):
+            if target.startswith("isbn:"):
+                # Parse textbook ref
+                try:
+                    ref = TextbookReference.parse(target)
+                    if ref in self._textbooks:
+                        textbooks.append(self._textbooks[ref])
+                except ValueError:
+                    pass
+        return textbooks
+
+    # --- Export for Visualization ---
+
+    def to_graph_data(self) -> dict:
+        """
+        Export graph in format compatible with visualization.
+
+        Returns dict with 'nodes' and 'links' arrays.
+        """
+        nodes = []
+        links = []
+
+        # Add course nodes
+        for ref, course in self._courses.items():
+            nodes.append({
+                "id": str(ref),
+                "label": ref.code,
+                "title": course.title,
+                "institution": ref.institution,
+                "type": NodeType.COURSE.value,
+                "credits": course.credits,
+            })
+
+        # Add textbook nodes
+        for ref, textbook in self._textbooks.items():
+            nodes.append({
+                "id": str(ref),
+                "label": textbook.title[:30],
+                "title": str(textbook),
+                "type": NodeType.TEXTBOOK.value,
+                "authors": textbook.authors,
+                "isbn": textbook.isbn,
+            })
+
+        # Add work requirement nodes
+        for ref, work in self._work_requirements.items():
+            nodes.append({
+                "id": str(ref),
+                "label": work.title,
+                "title": work.description,
+                "institution": ref.course_ref.institution,
+                "type": NodeType.WORK_REQUIREMENT.value,
+                "work_type": ref.req_type.value,
+                "weight": work.weight_percent,
+                "course": str(ref.course_ref),
+            })
+
+        # Add exam nodes
+        for ref, exam in self._exams.items():
+            nodes.append({
+                "id": str(ref),
+                "label": exam.title,
+                "title": exam.description,
+                "institution": ref.course_ref.institution,
+                "type": NodeType.EXAM.value,
+                "weight": exam.weight_percent,
+                "duration_minutes": exam.duration_minutes,
+                "course": str(ref.course_ref),
+            })
+
+        # Add all edges
+        for source, targets in self._forward.items():
+            for target in targets:
+                edge_type = self._edge_types.get((source, target), EdgeType.DEPENDS_ON)
+                links.append({
+                    "source": source,
+                    "target": target,
+                    "type": edge_type.value,
+                })
+
+        return {"nodes": nodes, "links": links}
+
+    def stats(self) -> dict:
+        """Get graph statistics."""
+        return {
+            "total_courses": len(self._courses),
+            "total_textbooks": len(self._textbooks),
+            "total_work_requirements": len(self._work_requirements),
+            "total_exams": len(self._exams),
+            "total_edges": sum(len(targets) for targets in self._forward.values()),
+            "edge_types": {
+                et.value: sum(1 for e in self._edge_types.values() if e == et)
+                for et in EdgeType
+            },
+        }
+
+
+def build_curriculum_from_courses(
+    courses: list[UnifiedCourse],
+    completions: Optional[list[CourseCompletion]] = None
+) -> CurriculumGraph:
+    """
+    Build a curriculum graph from courses and optional completion data.
+
+    Args:
+        courses: List of courses to add
+        completions: Optional list of course completion data
+
+    Returns:
+        CurriculumGraph with all data added
+    """
+    graph = CurriculumGraph()
+
+    for course in courses:
+        graph.add_course(course)
+
+    if completions:
+        for completion in completions:
+            graph.add_course_completion(completion)
+
+    return graph

--- a/devvyn/institutions/base.py
+++ b/devvyn/institutions/base.py
@@ -89,6 +89,24 @@ class UnifiedCourse:
     # e.g., [[ref1, ref2], [ref3, ref4]] means "(ref1 OR ref2) AND (ref3 OR ref4)"
     prerequisite_alternatives: list[list[CourseReference]] = field(default_factory=list)
 
+    # Textbooks (ISBNs of required/recommended books)
+    textbook_isbns: list[str] = field(default_factory=list)
+
+    # Course completion structure
+    has_final_exam: bool = True
+    has_midterm: bool = False
+    has_labs: bool = False
+    has_assignments: bool = True
+    has_project: bool = False
+
+    # Grading weights (if known)
+    final_exam_weight: float = 0.0      # Percentage (e.g., 40.0 for 40%)
+    midterm_weight: float = 0.0
+    assignments_weight: float = 0.0
+    labs_weight: float = 0.0
+    project_weight: float = 0.0
+    participation_weight: float = 0.0
+
     # Metadata
     url: str = ""
     fetched_at: Optional[datetime] = None

--- a/devvyn/model/course_materials.py
+++ b/devvyn/model/course_materials.py
@@ -1,0 +1,479 @@
+"""
+Data models for course materials, work requirements, and examinations.
+
+Extends the knowledge graph to include:
+- Textbooks and learning resources
+- Work requirements (assignments, labs, projects, readings)
+- Final exams as culmination nodes in the directed graph
+
+These form a directed graph where:
+  Course → Textbooks (readings)
+  Course → WorkRequirements (assignments, labs, projects)
+  WorkRequirements → FinalExam (exam depends on completing work)
+"""
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from devvyn.institutions.base import CourseReference
+
+
+class WorkRequirementType(Enum):
+    """Types of work requirements for course completion."""
+    ASSIGNMENT = "assignment"           # Written or coding assignments
+    LAB = "lab"                         # Laboratory exercises
+    PROJECT = "project"                 # Larger project work
+    READING = "reading"                 # Required reading from textbook
+    QUIZ = "quiz"                       # In-class or online quizzes
+    PARTICIPATION = "participation"     # Class participation
+    PRESENTATION = "presentation"       # Oral presentations
+    TUTORIAL = "tutorial"               # Tutorial attendance/work
+    MIDTERM = "midterm"                 # Midterm examination
+    FINAL_EXAM = "final_exam"           # Final examination
+
+
+class MaterialType(Enum):
+    """Types of learning materials."""
+    TEXTBOOK = "textbook"
+    REFERENCE_BOOK = "reference_book"
+    ONLINE_RESOURCE = "online_resource"
+    LECTURE_NOTES = "lecture_notes"
+    VIDEO_SERIES = "video_series"
+    SOFTWARE_TOOL = "software_tool"
+
+
+@dataclass(frozen=True)
+class TextbookReference:
+    """
+    Unique reference to a textbook.
+
+    Uses ISBN-13 as primary identifier when available.
+    """
+    isbn: str                    # ISBN-13 (or ISBN-10)
+    institution: str = ""        # Optional: institution-specific ID
+
+    def __str__(self) -> str:
+        if self.institution:
+            return f"{self.institution}:isbn:{self.isbn}"
+        return f"isbn:{self.isbn}"
+
+    @classmethod
+    def parse(cls, s: str) -> "TextbookReference":
+        """Parse from 'isbn:...' or 'institution:isbn:...' format."""
+        parts = s.split(":")
+        if len(parts) == 2 and parts[0] == "isbn":
+            return cls(isbn=parts[1])
+        if len(parts) == 3 and parts[1] == "isbn":
+            return cls(institution=parts[0], isbn=parts[2])
+        raise ValueError(f"Invalid textbook reference: {s}")
+
+
+@dataclass
+class Textbook:
+    """
+    A textbook or learning resource used in courses.
+
+    Can be shared across multiple courses and institutions.
+    """
+    ref: TextbookReference
+    title: str
+    authors: list[str] = field(default_factory=list)
+    edition: str = ""
+    publisher: str = ""
+    year: int = 0
+    material_type: MaterialType = MaterialType.TEXTBOOK
+
+    # Content organization
+    chapters: list[str] = field(default_factory=list)  # Chapter titles
+    total_pages: int = 0
+
+    # Metadata
+    url: str = ""                       # Publisher or bookstore URL
+    cover_image_url: str = ""
+
+    @property
+    def isbn(self) -> str:
+        return self.ref.isbn
+
+    def __str__(self) -> str:
+        author_str = ", ".join(self.authors[:2])
+        if len(self.authors) > 2:
+            author_str += " et al."
+        return f"{author_str} - {self.title}"
+
+
+@dataclass(frozen=True)
+class WorkRequirementRef:
+    """
+    Unique reference to a work requirement within a course.
+
+    Format: institution:course_code:type:identifier
+    Example: usask:CMPT141:assignment:a1
+    """
+    course_ref: CourseReference
+    req_type: WorkRequirementType
+    identifier: str              # e.g., "a1", "lab03", "project"
+
+    def __str__(self) -> str:
+        return f"{self.course_ref}:{self.req_type.value}:{self.identifier}"
+
+    @classmethod
+    def parse(cls, s: str) -> "WorkRequirementRef":
+        """Parse from 'institution:course:type:id' format."""
+        parts = s.split(":")
+        if len(parts) != 4:
+            raise ValueError(f"Invalid work requirement reference: {s}")
+        course_ref = CourseReference(institution=parts[0], code=parts[1])
+        req_type = WorkRequirementType(parts[2])
+        return cls(course_ref=course_ref, req_type=req_type, identifier=parts[3])
+
+
+@dataclass
+class WorkRequirement:
+    """
+    A work requirement for course completion.
+
+    Represents assignments, labs, projects, readings, etc. that students
+    must complete as part of a course.
+    """
+    ref: WorkRequirementRef
+    title: str
+    description: str = ""
+
+    # Weight and effort
+    weight_percent: float = 0.0         # Percentage of final grade
+    estimated_hours: float = 0.0        # Estimated time to complete
+
+    # Dependencies within the course (e.g., lab2 requires lab1)
+    depends_on: list[WorkRequirementRef] = field(default_factory=list)
+
+    # Associated readings from textbook(s)
+    textbook_readings: list[tuple[TextbookReference, str]] = field(default_factory=list)
+    # Each tuple is (textbook_ref, chapter/section specifier)
+    # e.g., (isbn_ref, "Chapter 3"), (isbn_ref, "Sections 4.1-4.3")
+
+    # Scheduling
+    due_week: Optional[int] = None      # Week of term when due
+    is_group_work: bool = False
+
+    @property
+    def course_ref(self) -> CourseReference:
+        return self.ref.course_ref
+
+    @property
+    def req_type(self) -> WorkRequirementType:
+        return self.ref.req_type
+
+    def __str__(self) -> str:
+        return f"{self.ref.req_type.value}: {self.title}"
+
+
+@dataclass(frozen=True)
+class ExamRef:
+    """
+    Unique reference to an exam.
+
+    Format: institution:course_code:exam_type
+    Example: usask:CMPT141:final_exam
+    """
+    course_ref: CourseReference
+    exam_type: str = "final"     # "final", "midterm1", "midterm2"
+
+    def __str__(self) -> str:
+        return f"{self.course_ref}:exam:{self.exam_type}"
+
+    @classmethod
+    def parse(cls, s: str) -> "ExamRef":
+        """Parse from 'institution:course:exam:type' format."""
+        parts = s.split(":")
+        if len(parts) != 4 or parts[2] != "exam":
+            raise ValueError(f"Invalid exam reference: {s}")
+        course_ref = CourseReference(institution=parts[0], code=parts[1])
+        return cls(course_ref=course_ref, exam_type=parts[3])
+
+
+@dataclass
+class FinalExam:
+    """
+    A final examination for a course.
+
+    In the directed graph model, the final exam is a terminus node that:
+    - Depends on all work requirements being completed
+    - Depends on textbook readings being done
+    - Represents the culmination of course learning
+
+    Graph relationships:
+        WorkRequirement_1 ──┐
+        WorkRequirement_2 ──┼──► FinalExam
+        TextbookReading_N ──┘
+    """
+    ref: ExamRef
+    title: str = "Final Examination"
+    description: str = ""
+
+    # Exam characteristics
+    weight_percent: float = 0.0         # Percentage of final grade (often 30-50%)
+    duration_minutes: int = 180         # Exam length
+    is_cumulative: bool = True          # Covers all course material
+
+    # Exam format
+    has_multiple_choice: bool = False
+    has_short_answer: bool = False
+    has_long_answer: bool = False
+    has_coding_problems: bool = False
+    has_proofs: bool = False
+
+    # Prerequisites for writing the exam (graph edges)
+    # These are the work requirements that must be done before the exam
+    required_work: list[WorkRequirementRef] = field(default_factory=list)
+
+    # Topics covered (maps to textbook sections)
+    topics: list[str] = field(default_factory=list)
+    textbook_coverage: list[tuple[TextbookReference, str]] = field(default_factory=list)
+
+    # Scheduling
+    exam_period: str = ""               # e.g., "December 2025", "April 2026"
+
+    # Minimum requirements
+    min_grade_percent: float = 0.0      # Minimum grade needed on exam to pass course
+
+    @property
+    def course_ref(self) -> CourseReference:
+        return self.ref.course_ref
+
+    def __str__(self) -> str:
+        return f"{self.course_ref}: {self.title}"
+
+
+@dataclass
+class CourseCompletion:
+    """
+    Aggregates all completion requirements for a course.
+
+    This model ties together:
+    - The course itself
+    - Required textbooks and materials
+    - All work requirements (assignments, labs, projects)
+    - The final exam as the terminal node
+
+    The directed graph structure:
+
+        ┌── Textbook ──────────────────────────┐
+        │       │                              │
+        │       ▼                              ▼
+        │   Reading 1 ──► Assignment 1 ──┐
+        │                                │
+    Course   Reading 2 ──► Lab 1 ────────┼──► FinalExam
+        │                                │
+        │   Reading 3 ──► Project ───────┘
+        │       │
+        └───────┴──────────────────────────────┘
+    """
+    course_ref: CourseReference
+    course_title: str = ""
+
+    # Materials
+    required_textbooks: list[Textbook] = field(default_factory=list)
+    recommended_textbooks: list[Textbook] = field(default_factory=list)
+
+    # Work requirements
+    assignments: list[WorkRequirement] = field(default_factory=list)
+    labs: list[WorkRequirement] = field(default_factory=list)
+    projects: list[WorkRequirement] = field(default_factory=list)
+    readings: list[WorkRequirement] = field(default_factory=list)
+    quizzes: list[WorkRequirement] = field(default_factory=list)
+    other_work: list[WorkRequirement] = field(default_factory=list)
+
+    # Midterm exams (not final)
+    midterms: list[FinalExam] = field(default_factory=list)
+
+    # Terminal node
+    final_exam: Optional[FinalExam] = None
+
+    # Calculated totals
+    total_work_weight: float = 0.0      # Sum of all work requirement weights
+    exam_weight: float = 0.0            # Sum of all exam weights
+
+    @property
+    def all_work_requirements(self) -> list[WorkRequirement]:
+        """Get all work requirements in order."""
+        return (
+            self.readings +
+            self.assignments +
+            self.labs +
+            self.quizzes +
+            self.projects +
+            self.other_work
+        )
+
+    @property
+    def all_exams(self) -> list[FinalExam]:
+        """Get all exams including midterms and final."""
+        exams = list(self.midterms)
+        if self.final_exam:
+            exams.append(self.final_exam)
+        return exams
+
+    def __post_init__(self):
+        """Calculate weight totals."""
+        self.total_work_weight = sum(w.weight_percent for w in self.all_work_requirements)
+        self.exam_weight = sum(e.weight_percent for e in self.all_exams)
+
+    def build_dependency_graph(self) -> dict[str, list[str]]:
+        """
+        Build a dependency graph of work requirements leading to the final exam.
+
+        Returns dict mapping node IDs to their dependencies.
+        """
+        graph: dict[str, list[str]] = {}
+
+        # Add work requirements
+        for work in self.all_work_requirements:
+            node_id = str(work.ref)
+            deps = [str(d) for d in work.depends_on]
+            # Also add implicit dependency on readings
+            for textbook_ref, section in work.textbook_readings:
+                reading_id = f"{textbook_ref}:{section}"
+                if reading_id not in deps:
+                    deps.append(reading_id)
+            graph[node_id] = deps
+
+        # Add final exam as terminal node
+        if self.final_exam:
+            exam_id = str(self.final_exam.ref)
+            # Final exam depends on all required work
+            deps = [str(w) for w in self.final_exam.required_work]
+            # If no explicit dependencies, depend on all work
+            if not deps:
+                deps = [str(w.ref) for w in self.all_work_requirements]
+            graph[exam_id] = deps
+
+        return graph
+
+    def validate_weights(self) -> list[str]:
+        """Validate that weights sum to approximately 100%."""
+        total = self.total_work_weight + self.exam_weight
+        issues = []
+        if total < 99.0:
+            issues.append(f"Total weight is only {total:.1f}% (missing {100-total:.1f}%)")
+        elif total > 101.0:
+            issues.append(f"Total weight exceeds 100% ({total:.1f}%)")
+        return issues
+
+
+# --- Graph Node Types ---
+
+class NodeType(Enum):
+    """Types of nodes in the knowledge graph."""
+    COURSE = "course"
+    TEXTBOOK = "textbook"
+    WORK_REQUIREMENT = "work_requirement"
+    EXAM = "exam"
+    PROGRAM = "program"
+
+
+@dataclass
+class GraphNode:
+    """
+    A node in the extended knowledge graph.
+
+    Allows representing courses, textbooks, work requirements, and exams
+    in a unified graph structure.
+    """
+    id: str                      # Unique identifier (e.g., "usask:CMPT141:exam:final")
+    node_type: NodeType
+    label: str                   # Display label
+    title: str = ""              # Full title
+    institution: str = ""        # Associated institution
+
+    # Type-specific data
+    course_ref: Optional[CourseReference] = None
+    textbook_ref: Optional[TextbookReference] = None
+    work_ref: Optional[WorkRequirementRef] = None
+    exam_ref: Optional[ExamRef] = None
+
+    # For visualization
+    weight: float = 1.0          # Node importance/size
+    group: str = ""              # Grouping for layout
+
+    @classmethod
+    def from_course(cls, course_ref: CourseReference, title: str = "") -> "GraphNode":
+        return cls(
+            id=str(course_ref),
+            node_type=NodeType.COURSE,
+            label=course_ref.code,
+            title=title,
+            institution=course_ref.institution,
+            course_ref=course_ref,
+            group="course"
+        )
+
+    @classmethod
+    def from_textbook(cls, textbook: Textbook) -> "GraphNode":
+        return cls(
+            id=str(textbook.ref),
+            node_type=NodeType.TEXTBOOK,
+            label=textbook.title[:30] + "..." if len(textbook.title) > 30 else textbook.title,
+            title=str(textbook),
+            textbook_ref=textbook.ref,
+            group="textbook"
+        )
+
+    @classmethod
+    def from_work_requirement(cls, work: WorkRequirement) -> "GraphNode":
+        return cls(
+            id=str(work.ref),
+            node_type=NodeType.WORK_REQUIREMENT,
+            label=work.title,
+            title=work.description,
+            institution=work.course_ref.institution,
+            work_ref=work.ref,
+            weight=work.weight_percent / 10,  # Scale for visualization
+            group=work.req_type.value
+        )
+
+    @classmethod
+    def from_exam(cls, exam: FinalExam) -> "GraphNode":
+        return cls(
+            id=str(exam.ref),
+            node_type=NodeType.EXAM,
+            label=exam.title,
+            title=exam.description,
+            institution=exam.course_ref.institution,
+            exam_ref=exam.ref,
+            weight=exam.weight_percent / 10,
+            group="exam"
+        )
+
+
+class EdgeType(Enum):
+    """Types of edges in the knowledge graph."""
+    PREREQUISITE = "prerequisite"         # Course → Course
+    COREQUISITE = "corequisite"           # Course ↔ Course
+    USES_TEXTBOOK = "uses_textbook"       # Course → Textbook
+    REQUIRES_READING = "requires_reading" # WorkReq → Textbook section
+    DEPENDS_ON = "depends_on"             # WorkReq → WorkReq
+    LEADS_TO_EXAM = "leads_to_exam"       # WorkReq → Exam
+    TRANSFER = "transfer"                 # Course → Course (cross-institution)
+
+
+@dataclass
+class GraphEdge:
+    """
+    An edge in the extended knowledge graph.
+    """
+    source: str                  # Source node ID
+    target: str                  # Target node ID
+    edge_type: EdgeType
+    label: str = ""              # Optional label
+    weight: float = 1.0          # Edge weight for visualization
+
+    def as_dict(self) -> dict:
+        return {
+            "source": self.source,
+            "target": self.target,
+            "type": self.edge_type.value,
+            "label": self.label,
+            "weight": self.weight
+        }

--- a/scripts/export_graph.py
+++ b/scripts/export_graph.py
@@ -2,6 +2,12 @@
 """
 Export REAL course data to graph-data.json for visualizations.
 NO hardcoded degree models - only real API/scraped data.
+
+Supports extended graph with:
+- Courses (existing)
+- Textbooks (new)
+- Work requirements (new)
+- Exams as terminal nodes (new)
 """
 import asyncio
 import json
@@ -105,12 +111,106 @@ async def export_graph_data(output_path: str = "viz/graph-data.json"):
     except Exception as e:
         print(f"  Transfers: error - {e}")
 
+    # Add course completion data (textbooks, work requirements, exams)
+    print("Loading course completion data...")
+    try:
+        from devvyn.data.sample_course_completion import get_sample_completions
+
+        completions = get_sample_completions()
+        textbook_count = 0
+        work_count = 0
+        exam_count = 0
+
+        for completion in completions:
+            course_id = f"{completion.course_ref.institution}:{completion.course_ref.code}"
+
+            # Add textbooks
+            for textbook in completion.required_textbooks + completion.recommended_textbooks:
+                tb_id = str(textbook.ref)
+                nodes.append({
+                    "id": tb_id,
+                    "label": textbook.title[:30] + "..." if len(textbook.title) > 30 else textbook.title,
+                    "title": str(textbook),
+                    "type": "textbook",
+                    "isbn": textbook.isbn,
+                    "authors": textbook.authors,
+                })
+                textbook_count += 1
+
+                # Link course to textbook
+                links.append({
+                    "source": course_id,
+                    "target": tb_id,
+                    "type": "uses_textbook",
+                })
+
+            # Add work requirements
+            for work in completion.all_work_requirements:
+                work_id = str(work.ref)
+                nodes.append({
+                    "id": work_id,
+                    "label": work.title,
+                    "title": work.description,
+                    "type": "work_requirement",
+                    "work_type": work.req_type.value,
+                    "weight": work.weight_percent,
+                    "course": course_id,
+                    "institution": completion.course_ref.institution,
+                })
+                work_count += 1
+
+                # Add dependency links
+                for dep in work.depends_on:
+                    links.append({
+                        "source": str(dep),
+                        "target": work_id,
+                        "type": "depends_on",
+                    })
+
+            # Add exams (including midterms and final)
+            for exam in completion.all_exams:
+                exam_id = str(exam.ref)
+                nodes.append({
+                    "id": exam_id,
+                    "label": exam.title,
+                    "title": exam.description,
+                    "type": "exam",
+                    "weight": exam.weight_percent,
+                    "duration_minutes": exam.duration_minutes,
+                    "course": course_id,
+                    "institution": completion.course_ref.institution,
+                })
+                exam_count += 1
+
+                # Add links from work requirements to exam
+                for work_ref in exam.required_work:
+                    links.append({
+                        "source": str(work_ref),
+                        "target": exam_id,
+                        "type": "leads_to_exam",
+                    })
+
+        print(f"  {len(completions)} course completions")
+        print(f"  {textbook_count} textbooks")
+        print(f"  {work_count} work requirements")
+        print(f"  {exam_count} exams (terminal nodes)")
+    except ImportError:
+        print("  (sample data not available)")
+    except Exception as e:
+        print(f"  Error: {e}")
+
     # Filter out links referencing missing nodes
     node_ids = set(n["id"] for n in nodes)
     valid_links = []
     for link in links:
         if link["source"] in node_ids and link["target"] in node_ids:
             valid_links.append(link)
+
+    # Count node types
+    course_nodes = len([n for n in nodes if n.get("type") == "course"])
+    textbook_nodes = len([n for n in nodes if n.get("type") == "textbook"])
+    work_nodes = len([n for n in nodes if n.get("type") == "work_requirement"])
+    exam_nodes = len([n for n in nodes if n.get("type") == "exam"])
 
     data = {
         "nodes": nodes,
@@ -124,10 +224,13 @@ async def export_graph_data(output_path: str = "viz/graph-data.json"):
         json.dump(data, f, indent=2)
 
     print(f"\nExported {len(nodes)} nodes and {len(valid_links)} links to {output}")
-    print(f"  - {len(nodes)} courses (REAL DATA)")
+    print(f"  - {course_nodes} courses (REAL DATA)")
+    print(f"  - {textbook_nodes} textbooks")
+    print(f"  - {work_nodes} work requirements")
+    print(f"  - {exam_nodes} exams (terminal nodes)")
     print(f"  - {len([l for l in valid_links if l['type'] == 'prerequisite'])} prerequisites")
     print(f"  - {len([l for l in valid_links if l['type'] == 'transfer'])} transfers")
-    print(f"  - 0 fake degree models")
+    print(f"  - {len([l for l in valid_links if l['type'] == 'leads_to_exam'])} exam dependencies")
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,434 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "aiolimiter"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/23/b52debf471f7a1e42e362d959a3982bdcb4fe13a5d46e63d28868807a79c/aiolimiter-1.2.1.tar.gz", hash = "sha256:e02a37ea1a855d9e832252a105420ad4d15011505512a1a1d814647451b5cca9", size = 7185, upload-time = "2024-12-08T15:31:51.496Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/ba/df6e8e1045aebc4778d19b8a3a9bc1808adb1619ba94ca354d9ba17d86c3/aiolimiter-1.2.1-py3-none-any.whl", hash = "sha256:d3f249e9059a20badcb56b61601a83556133655c11d1eb3dd3e04ff069e5f3c7", size = 6711, upload-time = "2024-12-08T15:31:49.874Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "flask"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blinker" },
+    { name = "click" },
+    { name = "itsdangerous" },
+    { name = "jinja2" },
+    { name = "markupsafe" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/6d/cfe3c0fcc5e477df242b98bfe186a4c34357b4847e87ecaef04507332dab/flask-3.1.2.tar.gz", hash = "sha256:bf656c15c80190ed628ad08cdfd3aaa35beb087855e2f494910aa3774cc4fd87", size = 720160, upload-time = "2025-08-19T21:03:21.205Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/f9/7f9263c5695f4bd0023734af91bedb2ff8209e8de6ead162f35d8dc762fd/flask-3.1.2-py3-none-any.whl", hash = "sha256:ca1d8112ec8a6158cc29ea4858963350011b5c846a414cdb7a954aa9e967d03c", size = 103308, upload-time = "2025-08-19T21:03:19.499Z" },
+]
+
+[[package]]
+name = "flask-cors"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/74/0fc0fa68d62f21daef41017dafab19ef4b36551521260987eb3a5394c7ba/flask_cors-6.0.2.tar.gz", hash = "sha256:6e118f3698249ae33e429760db98ce032a8bf9913638d085ca0f4c5534ad2423", size = 13472, upload-time = "2025-12-12T20:31:42.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/af/72ad54402e599152de6d067324c46fe6a4f531c7c65baf7e96c63db55eaf/flask_cors-6.0.2-py3-none-any.whl", hash = "sha256:e57544d415dfd7da89a9564e1e3a9e515042df76e12130641ca6f3f2f03b699a", size = 13257, upload-time = "2025-12-12T20:31:41.3Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "knowledge-mapper"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "aiolimiter" },
+    { name = "flask" },
+    { name = "flask-cors" },
+    { name = "httpx" },
+    { name = "lxml" },
+    { name = "typeguard" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiolimiter", specifier = ">=1.1" },
+    { name = "flask", specifier = ">=3.0" },
+    { name = "flask-cors", specifier = ">=4.0" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "lxml", specifier = ">=5.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+    { name = "typeguard", specifier = ">=4.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "lxml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/88/262177de60548e5a2bfc46ad28232c9e9cbde697bd94132aeb80364675cb/lxml-6.0.2.tar.gz", hash = "sha256:cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62", size = 4073426, upload-time = "2025-09-22T04:04:59.287Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/c8/8ff2bc6b920c84355146cd1ab7d181bc543b89241cfb1ebee824a7c81457/lxml-6.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a59f5448ba2ceccd06995c95ea59a7674a10de0810f2ce90c9006f3cbc044456", size = 8661887, upload-time = "2025-09-22T04:01:17.265Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/9aae1008083bb501ef63284220ce81638332f9ccbfa53765b2b7502203cf/lxml-6.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e8113639f3296706fbac34a30813929e29247718e88173ad849f57ca59754924", size = 4667818, upload-time = "2025-09-22T04:01:19.688Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ca/31fb37f99f37f1536c133476674c10b577e409c0a624384147653e38baf2/lxml-6.0.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a8bef9b9825fa8bc816a6e641bb67219489229ebc648be422af695f6e7a4fa7f", size = 4950807, upload-time = "2025-09-22T04:01:21.487Z" },
+    { url = "https://files.pythonhosted.org/packages/da/87/f6cb9442e4bada8aab5ae7e1046264f62fdbeaa6e3f6211b93f4c0dd97f1/lxml-6.0.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:65ea18d710fd14e0186c2f973dc60bb52039a275f82d3c44a0e42b43440ea534", size = 5109179, upload-time = "2025-09-22T04:01:23.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/20/a7760713e65888db79bbae4f6146a6ae5c04e4a204a3c48896c408cd6ed2/lxml-6.0.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c371aa98126a0d4c739ca93ceffa0fd7a5d732e3ac66a46e74339acd4d334564", size = 5023044, upload-time = "2025-09-22T04:01:25.118Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b0/7e64e0460fcb36471899f75831509098f3fd7cd02a3833ac517433cb4f8f/lxml-6.0.2-cp312-cp312-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:700efd30c0fa1a3581d80a748157397559396090a51d306ea59a70020223d16f", size = 5359685, upload-time = "2025-09-22T04:01:27.398Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e1/e5df362e9ca4e2f48ed6411bd4b3a0ae737cc842e96877f5bf9428055ab4/lxml-6.0.2-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c33e66d44fe60e72397b487ee92e01da0d09ba2d66df8eae42d77b6d06e5eba0", size = 5654127, upload-time = "2025-09-22T04:01:29.629Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d1/232b3309a02d60f11e71857778bfcd4acbdb86c07db8260caf7d008b08f8/lxml-6.0.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90a345bbeaf9d0587a3aaffb7006aa39ccb6ff0e96a57286c0cb2fd1520ea192", size = 5253958, upload-time = "2025-09-22T04:01:31.535Z" },
+    { url = "https://files.pythonhosted.org/packages/35/35/d955a070994725c4f7d80583a96cab9c107c57a125b20bb5f708fe941011/lxml-6.0.2-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:064fdadaf7a21af3ed1dcaa106b854077fbeada827c18f72aec9346847cd65d0", size = 4711541, upload-time = "2025-09-22T04:01:33.801Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/be/667d17363b38a78c4bd63cfd4b4632029fd68d2c2dc81f25ce9eb5224dd5/lxml-6.0.2-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fbc74f42c3525ac4ffa4b89cbdd00057b6196bcefe8bce794abd42d33a018092", size = 5267426, upload-time = "2025-09-22T04:01:35.639Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/62c70aa4a1c26569bc958c9ca86af2bb4e1f614e8c04fb2989833874f7ae/lxml-6.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6ddff43f702905a4e32bc24f3f2e2edfe0f8fde3277d481bffb709a4cced7a1f", size = 5064917, upload-time = "2025-09-22T04:01:37.448Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/55/6ceddaca353ebd0f1908ef712c597f8570cc9c58130dbb89903198e441fd/lxml-6.0.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6da5185951d72e6f5352166e3da7b0dc27aa70bd1090b0eb3f7f7212b53f1bb8", size = 4788795, upload-time = "2025-09-22T04:01:39.165Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e8/fd63e15da5e3fd4c2146f8bbb3c14e94ab850589beab88e547b2dbce22e1/lxml-6.0.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:57a86e1ebb4020a38d295c04fc79603c7899e0df71588043eb218722dabc087f", size = 5676759, upload-time = "2025-09-22T04:01:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/76/47/b3ec58dc5c374697f5ba37412cd2728f427d056315d124dd4b61da381877/lxml-6.0.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2047d8234fe735ab77802ce5f2297e410ff40f5238aec569ad7c8e163d7b19a6", size = 5255666, upload-time = "2025-09-22T04:01:43.363Z" },
+    { url = "https://files.pythonhosted.org/packages/19/93/03ba725df4c3d72afd9596eef4a37a837ce8e4806010569bedfcd2cb68fd/lxml-6.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f91fd2b2ea15a6800c8e24418c0775a1694eefc011392da73bc6cef2623b322", size = 5277989, upload-time = "2025-09-22T04:01:45.215Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/80/c06de80bfce881d0ad738576f243911fccf992687ae09fd80b734712b39c/lxml-6.0.2-cp312-cp312-win32.whl", hash = "sha256:3ae2ce7d6fedfb3414a2b6c5e20b249c4c607f72cb8d2bb7cc9c6ec7c6f4e849", size = 3611456, upload-time = "2025-09-22T04:01:48.243Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/d7/0cdfb6c3e30893463fb3d1e52bc5f5f99684a03c29a0b6b605cfae879cd5/lxml-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:72c87e5ee4e58a8354fb9c7c84cbf95a1c8236c127a5d1b7683f04bed8361e1f", size = 4011793, upload-time = "2025-09-22T04:01:50.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/93c73c67db235931527301ed3785f849c78991e2e34f3fd9a6663ffda4c5/lxml-6.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:61cb10eeb95570153e0c0e554f58df92ecf5109f75eacad4a95baa709e26c3d6", size = 3672836, upload-time = "2025-09-22T04:01:52.145Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/4e8f0540608977aea078bf6d79f128e0e2c2bba8af1acf775c30baa70460/lxml-6.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9b33d21594afab46f37ae58dfadd06636f154923c4e8a4d754b0127554eb2e77", size = 8648494, upload-time = "2025-09-22T04:01:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f4/2a94a3d3dfd6c6b433501b8d470a1960a20ecce93245cf2db1706adf6c19/lxml-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c8963287d7a4c5c9a432ff487c52e9c5618667179c18a204bdedb27310f022f", size = 4661146, upload-time = "2025-09-22T04:01:56.282Z" },
+    { url = "https://files.pythonhosted.org/packages/25/2e/4efa677fa6b322013035d38016f6ae859d06cac67437ca7dc708a6af7028/lxml-6.0.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1941354d92699fb5ffe6ed7b32f9649e43c2feb4b97205f75866f7d21aa91452", size = 4946932, upload-time = "2025-09-22T04:01:58.989Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/0f/526e78a6d38d109fdbaa5049c62e1d32fdd70c75fb61c4eadf3045d3d124/lxml-6.0.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb2f6ca0ae2d983ded09357b84af659c954722bbf04dea98030064996d156048", size = 5100060, upload-time = "2025-09-22T04:02:00.812Z" },
+    { url = "https://files.pythonhosted.org/packages/81/76/99de58d81fa702cc0ea7edae4f4640416c2062813a00ff24bd70ac1d9c9b/lxml-6.0.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb2a12d704f180a902d7fa778c6d71f36ceb7b0d317f34cdc76a5d05aa1dd1df", size = 5019000, upload-time = "2025-09-22T04:02:02.671Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/9e57d25482bc9a9882cb0037fdb9cc18f4b79d85df94fa9d2a89562f1d25/lxml-6.0.2-cp313-cp313-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:6ec0e3f745021bfed19c456647f0298d60a24c9ff86d9d051f52b509663feeb1", size = 5348496, upload-time = "2025-09-22T04:02:04.904Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/8e/cb99bd0b83ccc3e8f0f528e9aa1f7a9965dfec08c617070c5db8d63a87ce/lxml-6.0.2-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:846ae9a12d54e368933b9759052d6206a9e8b250291109c48e350c1f1f49d916", size = 5643779, upload-time = "2025-09-22T04:02:06.689Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/34/9e591954939276bb679b73773836c6684c22e56d05980e31d52a9a8deb18/lxml-6.0.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef9266d2aa545d7374938fb5c484531ef5a2ec7f2d573e62f8ce722c735685fd", size = 5244072, upload-time = "2025-09-22T04:02:08.587Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/27/b29ff065f9aaca443ee377aff699714fcbffb371b4fce5ac4ca759e436d5/lxml-6.0.2-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:4077b7c79f31755df33b795dc12119cb557a0106bfdab0d2c2d97bd3cf3dffa6", size = 4718675, upload-time = "2025-09-22T04:02:10.783Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f756f9c2cd27caa1a6ef8c32ae47aadea697f5c2c6d07b0dae133c244fbe/lxml-6.0.2-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a7c5d5e5f1081955358533be077166ee97ed2571d6a66bdba6ec2f609a715d1a", size = 5255171, upload-time = "2025-09-22T04:02:12.631Z" },
+    { url = "https://files.pythonhosted.org/packages/61/46/bb85ea42d2cb1bd8395484fd72f38e3389611aa496ac7772da9205bbda0e/lxml-6.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8f8d0cbd0674ee89863a523e6994ac25fd5be9c8486acfc3e5ccea679bad2679", size = 5057175, upload-time = "2025-09-22T04:02:14.718Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0c/443fc476dcc8e41577f0af70458c50fe299a97bb6b7505bb1ae09aa7f9ac/lxml-6.0.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:2cbcbf6d6e924c28f04a43f3b6f6e272312a090f269eff68a2982e13e5d57659", size = 4785688, upload-time = "2025-09-22T04:02:16.957Z" },
+    { url = "https://files.pythonhosted.org/packages/48/78/6ef0b359d45bb9697bc5a626e1992fa5d27aa3f8004b137b2314793b50a0/lxml-6.0.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:dfb874cfa53340009af6bdd7e54ebc0d21012a60a4e65d927c2e477112e63484", size = 5660655, upload-time = "2025-09-22T04:02:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/ea/e1d33808f386bc1339d08c0dcada6e4712d4ed8e93fcad5f057070b7988a/lxml-6.0.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fb8dae0b6b8b7f9e96c26fdd8121522ce5de9bb5538010870bd538683d30e9a2", size = 5247695, upload-time = "2025-09-22T04:02:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/47/eba75dfd8183673725255247a603b4ad606f4ae657b60c6c145b381697da/lxml-6.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:358d9adae670b63e95bc59747c72f4dc97c9ec58881d4627fe0120da0f90d314", size = 5269841, upload-time = "2025-09-22T04:02:22.489Z" },
+    { url = "https://files.pythonhosted.org/packages/76/04/5c5e2b8577bc936e219becb2e98cdb1aca14a4921a12995b9d0c523502ae/lxml-6.0.2-cp313-cp313-win32.whl", hash = "sha256:e8cd2415f372e7e5a789d743d133ae474290a90b9023197fd78f32e2dc6873e2", size = 3610700, upload-time = "2025-09-22T04:02:24.465Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0a/4643ccc6bb8b143e9f9640aa54e38255f9d3b45feb2cbe7ae2ca47e8782e/lxml-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:b30d46379644fbfc3ab81f8f82ae4de55179414651f110a1514f0b1f8f6cb2d7", size = 4010347, upload-time = "2025-09-22T04:02:26.286Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ef/dcf1d29c3f530577f61e5fe2f1bd72929acf779953668a8a47a479ae6f26/lxml-6.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:13dcecc9946dca97b11b7c40d29fba63b55ab4170d3c0cf8c0c164343b9bfdcf", size = 3671248, upload-time = "2025-09-22T04:02:27.918Z" },
+    { url = "https://files.pythonhosted.org/packages/03/15/d4a377b385ab693ce97b472fe0c77c2b16ec79590e688b3ccc71fba19884/lxml-6.0.2-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:b0c732aa23de8f8aec23f4b580d1e52905ef468afb4abeafd3fec77042abb6fe", size = 8659801, upload-time = "2025-09-22T04:02:30.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e8/c128e37589463668794d503afaeb003987373c5f94d667124ffd8078bbd9/lxml-6.0.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4468e3b83e10e0317a89a33d28f7aeba1caa4d1a6fd457d115dd4ffe90c5931d", size = 4659403, upload-time = "2025-09-22T04:02:32.119Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ce/74903904339decdf7da7847bb5741fc98a5451b42fc419a86c0c13d26fe2/lxml-6.0.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:abd44571493973bad4598a3be7e1d807ed45aa2adaf7ab92ab7c62609569b17d", size = 4966974, upload-time = "2025-09-22T04:02:34.155Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d3/131dec79ce61c5567fecf82515bd9bc36395df42501b50f7f7f3bd065df0/lxml-6.0.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:370cd78d5855cfbffd57c422851f7d3864e6ae72d0da615fca4dad8c45d375a5", size = 5102953, upload-time = "2025-09-22T04:02:36.054Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ea/a43ba9bb750d4ffdd885f2cd333572f5bb900cd2408b67fdda07e85978a0/lxml-6.0.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:901e3b4219fa04ef766885fb40fa516a71662a4c61b80c94d25336b4934b71c0", size = 5055054, upload-time = "2025-09-22T04:02:38.154Z" },
+    { url = "https://files.pythonhosted.org/packages/60/23/6885b451636ae286c34628f70a7ed1fcc759f8d9ad382d132e1c8d3d9bfd/lxml-6.0.2-cp314-cp314-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:a4bf42d2e4cf52c28cc1812d62426b9503cdb0c87a6de81442626aa7d69707ba", size = 5352421, upload-time = "2025-09-22T04:02:40.413Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5b/fc2ddfc94ddbe3eebb8e9af6e3fd65e2feba4967f6a4e9683875c394c2d8/lxml-6.0.2-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2c7fdaa4d7c3d886a42534adec7cfac73860b89b4e5298752f60aa5984641a0", size = 5673684, upload-time = "2025-09-22T04:02:42.288Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/47293c58cc91769130fbf85531280e8cc7868f7fbb6d92f4670071b9cb3e/lxml-6.0.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98a5e1660dc7de2200b00d53fa00bcd3c35a3608c305d45a7bbcaf29fa16e83d", size = 5252463, upload-time = "2025-09-22T04:02:44.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/da/ba6eceb830c762b48e711ded880d7e3e89fc6c7323e587c36540b6b23c6b/lxml-6.0.2-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:dc051506c30b609238d79eda75ee9cab3e520570ec8219844a72a46020901e37", size = 4698437, upload-time = "2025-09-22T04:02:46.524Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/24/7be3f82cb7990b89118d944b619e53c656c97dc89c28cfb143fdb7cd6f4d/lxml-6.0.2-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8799481bbdd212470d17513a54d568f44416db01250f49449647b5ab5b5dccb9", size = 5269890, upload-time = "2025-09-22T04:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/dcfb9ea1e16c665efd7538fc5d5c34071276ce9220e234217682e7d2c4a5/lxml-6.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9261bb77c2dab42f3ecd9103951aeca2c40277701eb7e912c545c1b16e0e4917", size = 5097185, upload-time = "2025-09-22T04:02:50.746Z" },
+    { url = "https://files.pythonhosted.org/packages/21/04/a60b0ff9314736316f28316b694bccbbabe100f8483ad83852d77fc7468e/lxml-6.0.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:65ac4a01aba353cfa6d5725b95d7aed6356ddc0a3cd734de00124d285b04b64f", size = 4745895, upload-time = "2025-09-22T04:02:52.968Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/bd/7d54bd1846e5a310d9c715921c5faa71cf5c0853372adf78aee70c8d7aa2/lxml-6.0.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:b22a07cbb82fea98f8a2fd814f3d1811ff9ed76d0fc6abc84eb21527596e7cc8", size = 5695246, upload-time = "2025-09-22T04:02:54.798Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/5643d6ab947bc371da21323acb2a6e603cedbe71cb4c99c8254289ab6f4e/lxml-6.0.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d759cdd7f3e055d6bc8d9bec3ad905227b2e4c785dc16c372eb5b5e83123f48a", size = 5260797, upload-time = "2025-09-22T04:02:57.058Z" },
+    { url = "https://files.pythonhosted.org/packages/33/da/34c1ec4cff1eea7d0b4cd44af8411806ed943141804ac9c5d565302afb78/lxml-6.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:945da35a48d193d27c188037a05fec5492937f66fb1958c24fc761fb9d40d43c", size = 5277404, upload-time = "2025-09-22T04:02:58.966Z" },
+    { url = "https://files.pythonhosted.org/packages/82/57/4eca3e31e54dc89e2c3507e1cd411074a17565fa5ffc437c4ae0a00d439e/lxml-6.0.2-cp314-cp314-win32.whl", hash = "sha256:be3aaa60da67e6153eb15715cc2e19091af5dc75faef8b8a585aea372507384b", size = 3670072, upload-time = "2025-09-22T04:03:38.05Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/e0/c96cf13eccd20c9421ba910304dae0f619724dcf1702864fd59dd386404d/lxml-6.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:fa25afbadead523f7001caf0c2382afd272c315a033a7b06336da2637d92d6ed", size = 4080617, upload-time = "2025-09-22T04:03:39.835Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5d/b3f03e22b3d38d6f188ef044900a9b29b2fe0aebb94625ce9fe244011d34/lxml-6.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:063eccf89df5b24e361b123e257e437f9e9878f425ee9aae3144c77faf6da6d8", size = 3754930, upload-time = "2025-09-22T04:03:41.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/5c/42c2c4c03554580708fc738d13414801f340c04c3eff90d8d2d227145275/lxml-6.0.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6162a86d86893d63084faaf4ff937b3daea233e3682fb4474db07395794fa80d", size = 8910380, upload-time = "2025-09-22T04:03:01.645Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4f/12df843e3e10d18d468a7557058f8d3733e8b6e12401f30b1ef29360740f/lxml-6.0.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:414aaa94e974e23a3e92e7ca5b97d10c0cf37b6481f50911032c69eeb3991bba", size = 4775632, upload-time = "2025-09-22T04:03:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0c/9dc31e6c2d0d418483cbcb469d1f5a582a1cd00a1f4081953d44051f3c50/lxml-6.0.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48461bd21625458dd01e14e2c38dd0aea69addc3c4f960c30d9f59d7f93be601", size = 4975171, upload-time = "2025-09-22T04:03:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2b/9b870c6ca24c841bdd887504808f0417aa9d8d564114689266f19ddf29c8/lxml-6.0.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25fcc59afc57d527cfc78a58f40ab4c9b8fd096a9a3f964d2781ffb6eb33f4ed", size = 5110109, upload-time = "2025-09-22T04:03:07.452Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0c/4f5f2a4dd319a178912751564471355d9019e220c20d7db3fb8307ed8582/lxml-6.0.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5179c60288204e6ddde3f774a93350177e08876eaf3ab78aa3a3649d43eb7d37", size = 5041061, upload-time = "2025-09-22T04:03:09.297Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/554eed290365267671fe001a20d72d14f468ae4e6acef1e179b039436967/lxml-6.0.2-cp314-cp314t-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:967aab75434de148ec80597b75062d8123cadf2943fb4281f385141e18b21338", size = 5306233, upload-time = "2025-09-22T04:03:11.651Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/31/1d748aa275e71802ad9722df32a7a35034246b42c0ecdd8235412c3396ef/lxml-6.0.2-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d100fcc8930d697c6561156c6810ab4a508fb264c8b6779e6e61e2ed5e7558f9", size = 5604739, upload-time = "2025-09-22T04:03:13.592Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/41/2c11916bcac09ed561adccacceaedd2bf0e0b25b297ea92aab99fd03d0fa/lxml-6.0.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ca59e7e13e5981175b8b3e4ab84d7da57993eeff53c07764dcebda0d0e64ecd", size = 5225119, upload-time = "2025-09-22T04:03:15.408Z" },
+    { url = "https://files.pythonhosted.org/packages/99/05/4e5c2873d8f17aa018e6afde417c80cc5d0c33be4854cce3ef5670c49367/lxml-6.0.2-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:957448ac63a42e2e49531b9d6c0fa449a1970dbc32467aaad46f11545be9af1d", size = 4633665, upload-time = "2025-09-22T04:03:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c9/dcc2da1bebd6275cdc723b515f93edf548b82f36a5458cca3578bc899332/lxml-6.0.2-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b7fc49c37f1786284b12af63152fe1d0990722497e2d5817acfe7a877522f9a9", size = 5234997, upload-time = "2025-09-22T04:03:19.14Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e2/5172e4e7468afca64a37b81dba152fc5d90e30f9c83c7c3213d6a02a5ce4/lxml-6.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e19e0643cc936a22e837f79d01a550678da8377d7d801a14487c10c34ee49c7e", size = 5090957, upload-time = "2025-09-22T04:03:21.436Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b3/15461fd3e5cd4ddcb7938b87fc20b14ab113b92312fc97afe65cd7c85de1/lxml-6.0.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:1db01e5cf14345628e0cbe71067204db658e2fb8e51e7f33631f5f4735fefd8d", size = 4764372, upload-time = "2025-09-22T04:03:23.27Z" },
+    { url = "https://files.pythonhosted.org/packages/05/33/f310b987c8bf9e61c4dd8e8035c416bd3230098f5e3cfa69fc4232de7059/lxml-6.0.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:875c6b5ab39ad5291588aed6925fac99d0097af0dd62f33c7b43736043d4a2ec", size = 5634653, upload-time = "2025-09-22T04:03:25.767Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/51c80e75e0bc9382158133bdcf4e339b5886c6ee2418b5199b3f1a61ed6d/lxml-6.0.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:cdcbed9ad19da81c480dfd6dd161886db6096083c9938ead313d94b30aadf272", size = 5233795, upload-time = "2025-09-22T04:03:27.62Z" },
+    { url = "https://files.pythonhosted.org/packages/56/4d/4856e897df0d588789dd844dbed9d91782c4ef0b327f96ce53c807e13128/lxml-6.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:80dadc234ebc532e09be1975ff538d154a7fa61ea5031c03d25178855544728f", size = 5257023, upload-time = "2025-09-22T04:03:30.056Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/85/86766dfebfa87bea0ab78e9ff7a4b4b45225df4b4d3b8cc3c03c5cd68464/lxml-6.0.2-cp314-cp314t-win32.whl", hash = "sha256:da08e7bb297b04e893d91087df19638dc7a6bb858a954b0cc2b9f5053c922312", size = 3911420, upload-time = "2025-09-22T04:03:32.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1a/b248b355834c8e32614650b8008c69ffeb0ceb149c793961dd8c0b991bb3/lxml-6.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:252a22982dca42f6155125ac76d3432e548a7625d56f5a273ee78a5057216eca", size = 4406837, upload-time = "2025-09-22T04:03:34.027Z" },
+    { url = "https://files.pythonhosted.org/packages/92/aa/df863bcc39c5e0946263454aba394de8a9084dbaff8ad143846b0d844739/lxml-6.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:bb4c1847b303835d89d785a18801a883436cdfd5dc3d62947f9c49e24f0f5a2c", size = 3822205, upload-time = "2025-09-22T04:03:36.249Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "typeguard"
+version = "4.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/68/71c1a15b5f65f40e91b65da23b8224dad41349894535a97f63a52e462196/typeguard-4.4.4.tar.gz", hash = "sha256:3a7fd2dffb705d4d0efaed4306a704c89b9dee850b688f060a8b1615a79e5f74", size = 75203, upload-time = "2025-06-18T09:56:07.624Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/a9/e3aee762739c1d7528da1c3e06d518503f8b6c439c35549b53735ba52ead/typeguard-4.4.4-py3-none-any.whl", hash = "sha256:b5f562281b6bfa1f5492470464730ef001646128b180769880468bd84b68b09e", size = 34874, upload-time = "2025-06-18T09:56:05.999Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/70/1469ef1d3542ae7c2c7b72bd5e3a4e6ee69d7978fa8a3af05a38eca5becf/werkzeug-3.1.5.tar.gz", hash = "sha256:6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67", size = 864754, upload-time = "2026-01-08T17:49:23.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/e4/8d97cca767bcc1be76d16fb76951608305561c6e056811587f36cb1316a8/werkzeug-3.1.5-py3-none-any.whl", hash = "sha256:5111e36e91086ece91f93268bb39b4a35c1e6f1feac762c9c822ded0a4e322dc", size = 225025, upload-time = "2026-01-08T17:49:21.859Z" },
+]

--- a/viz/full-explorer.html
+++ b/viz/full-explorer.html
@@ -106,6 +106,9 @@
         .link.prerequisite { stroke: #8b949e; }
         .link.transfer { stroke: #f0883e; stroke-dasharray: 4,2; }
         .link.satisfies { stroke: #3fb950; stroke-opacity: 0.15; }
+        .link.uses_textbook { stroke: #d29922; stroke-dasharray: 2,2; }
+        .link.depends_on { stroke: #8957e5; }
+        .link.leads_to_exam { stroke: #f85149; stroke-width: 2px; }
         .link.highlighted { stroke-opacity: 1; stroke-width: 2px; }
 
         .dimmed { opacity: 0.1; }
@@ -195,6 +198,12 @@
                 <div class="filter-group">
                     <label><input type="checkbox" checked data-filter="type" value="course">Courses</label>
                     <label><input type="checkbox" checked data-filter="type" value="degree">Degrees</label>
+                    <label><input type="checkbox" checked data-filter="type" value="textbook">
+                        <span class="color-dot" style="background: #d29922;"></span>Textbooks</label>
+                    <label><input type="checkbox" checked data-filter="type" value="work_requirement">
+                        <span class="color-dot" style="background: #8957e5;"></span>Work Requirements</label>
+                    <label><input type="checkbox" checked data-filter="type" value="exam">
+                        <span class="color-dot" style="background: #f85149;"></span>Exams</label>
                 </div>
             </div>
 
@@ -204,6 +213,9 @@
                     <label><input type="checkbox" checked data-filter="link" value="prerequisite">Prerequisites</label>
                     <label><input type="checkbox" checked data-filter="link" value="transfer">Transfer Equiv.</label>
                     <label><input type="checkbox" data-filter="link" value="satisfies">Course→Degree</label>
+                    <label><input type="checkbox" checked data-filter="link" value="uses_textbook">Uses Textbook</label>
+                    <label><input type="checkbox" checked data-filter="link" value="depends_on">Work Dependencies</label>
+                    <label><input type="checkbox" checked data-filter="link" value="leads_to_exam">→ Exam</label>
                 </div>
             </div>
 
@@ -217,9 +229,13 @@
                 <div><span class="color-dot" style="background: #58a6ff;"></span>USask Course</div>
                 <div><span class="color-dot" style="background: #f0883e;"></span>SaskPolytech Course</div>
                 <div><span class="color-dot" style="background: #a371f7;"></span>Degree Program</div>
+                <div><span class="color-dot" style="background: #d29922;"></span>Textbook</div>
+                <div><span class="color-dot" style="background: #8957e5;"></span>Work Requirement</div>
+                <div><span class="color-dot" style="background: #f85149;"></span>Final Exam</div>
                 <div style="margin-top: 8px; border-top: 1px solid #30363d; padding-top: 8px;">
                     <div><span style="display:inline-block;width:20px;height:2px;background:#8b949e;margin-right:8px;"></span>Prerequisite</div>
                     <div><span style="display:inline-block;width:20px;height:2px;background:#f0883e;margin-right:8px;border-bottom:2px dashed #f0883e;"></span>Transfer</div>
+                    <div><span style="display:inline-block;width:20px;height:2px;background:#f85149;margin-right:8px;"></span>→ Exam</div>
                 </div>
             </div>
         </div>
@@ -232,6 +248,10 @@
         degree: '#a371f7',
         minor: '#3fb950',
         honours: '#db61a2',
+        // New node types
+        textbook: '#d29922',      // Gold for textbooks
+        work_requirement: '#8957e5', // Purple for work requirements
+        exam: '#f85149',          // Red for exams (terminal nodes)
     };
 
     let graphData = null;
@@ -239,8 +259,8 @@
     let svg, g, link, node;
     let currentFilters = {
         institutions: new Set(['usask', 'saskpolytech']),
-        types: new Set(['course', 'degree']),
-        linkTypes: new Set(['prerequisite', 'transfer'])
+        types: new Set(['course', 'degree', 'textbook', 'work_requirement', 'exam']),
+        linkTypes: new Set(['prerequisite', 'transfer', 'uses_textbook', 'depends_on', 'leads_to_exam'])
     };
 
     // Load data
@@ -302,9 +322,17 @@
             .on('mouseout', hideTooltip);
 
         node.append('circle')
-            .attr('r', d => d.type === 'degree' ? 12 : 6)
+            .attr('r', d => {
+                if (d.type === 'degree') return 12;
+                if (d.type === 'exam') return 10;  // Larger for terminal nodes
+                if (d.type === 'textbook') return 8;
+                return 6;
+            })
             .attr('fill', d => {
                 if (d.type === 'degree') return colors.degree;
+                if (d.type === 'textbook') return colors.textbook;
+                if (d.type === 'work_requirement') return colors.work_requirement;
+                if (d.type === 'exam') return colors.exam;
                 return colors[d.institution] || '#8b949e';
             });
 
@@ -344,6 +372,10 @@
         const spCourses = courses.filter(n => n.institution === 'saskpolytech').length;
         const prereqs = graphData.links.filter(l => l.type === 'prerequisite').length;
         const transfers = graphData.links.filter(l => l.type === 'transfer').length;
+        const textbooks = graphData.nodes.filter(n => n.type === 'textbook').length;
+        const workReqs = graphData.nodes.filter(n => n.type === 'work_requirement').length;
+        const exams = graphData.nodes.filter(n => n.type === 'exam').length;
+        const examLinks = graphData.links.filter(l => l.type === 'leads_to_exam').length;
 
         document.getElementById('stats').innerHTML = `
             <div><span>Total Courses</span><span>${courses.length}</span></div>
@@ -351,7 +383,12 @@
             <div><span>SaskPolytech</span><span>${spCourses}</span></div>
             <div><span>Prerequisites</span><span>${prereqs}</span></div>
             <div><span>Transfer Links</span><span>${transfers}</span></div>
-            <div><span>Degree Programs</span><span>8</span></div>
+            <div style="border-top: 1px solid #30363d; margin-top: 8px; padding-top: 8px;">
+                <span>Textbooks</span><span style="color: #d29922;">${textbooks}</span>
+            </div>
+            <div><span>Work Requirements</span><span style="color: #8957e5;">${workReqs}</span></div>
+            <div><span>Exams</span><span style="color: #f85149;">${exams}</span></div>
+            <div><span>Exam Dependencies</span><span>${examLinks}</span></div>
         `;
     }
 


### PR DESCRIPTION
Extends the curriculum model to include:
- Textbooks as learning material nodes with ISBN references
- Work requirements (assignments, labs, projects) with dependencies
- Final exams as terminal nodes in the directed graph

The graph now models complete course requirements:
  Course → Textbook → Readings → Assignments → Final Exam

New files:
- devvyn/model/course_materials.py: Core data models
- devvyn/graph/curriculum.py: Extended graph with new node types
- devvyn/data/sample_course_completion.py: Sample CMPT 141/145 data

Updated:
- UnifiedCourse: Added textbook and grading weight fields
- API: New endpoints for textbooks, work requirements, exams
- Visualization: New node types, colors, and filters